### PR TITLE
新增 Article Table 欄位 - clean_html、移除 html 中多餘的 backslash

### DIFF
--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -7,8 +7,9 @@ class ArticleController < ApplicationController
   end
 
   def create
-    response = HTTParty.get("https://extractorapi.com/api/v1/extractor/?apikey=e3e6d4d35cbf7ecc564ed3d42fca87a75cc242dc&url=#{url_params[:link]}")
+    response = HTTParty.get("https://extractorapi.com/api/v1/extractor/?apikey=e3e6d4d35cbf7ecc564ed3d42fca87a75cc242dc&url=#{url_params[:link]}&fields=domain,title,author,date_published,images,videos,clean_html")
     response_hash = JSON.parse(response.body)
+    clean_html = response_hash['clean_html'].gsub!(/\"/, '\'')
 
     if response.code == 200
       @article.assign_attributes({
@@ -17,7 +18,8 @@ class ArticleController < ApplicationController
         title: response_hash['title'],
         content: response_hash['text'],
         domain: response_hash['domain'],
-        images: response_hash['images']
+        images: response_hash['images'],
+        clean_html: clean_html
       })
       # @article.images = response_hash['images']
       @article.save

--- a/app/controllers/article_controller.rb
+++ b/app/controllers/article_controller.rb
@@ -3,7 +3,7 @@ class ArticleController < ApplicationController
   def index
     # @articles_json = current_user.articles.to_json
     @articles_solve_nplus1 = Article.with_attached_article_images   #解決 N+1 問題
-    @articles = Article.order(id: :desc)
+    @articles = current_user.articles.order(id: :desc)
   end
 
   def create

--- a/app/views/article/index.html.erb
+++ b/app/views/article/index.html.erb
@@ -4,7 +4,7 @@
   <% @articles.each do |article| %>
   <div class="card col-3">
     <a href="<%= article.link %>" target="_blank">
-       <%= image_tag(article.images.first, size:'300x200') if article.article_images.attached? %>
+       <%= image_tag(article.images[2], size:'300x200') if article.article_images.attached? %>
     </a>
     <div class="card-body">
       <a href="<%= article.link %>" target="_blank" class="card-text"><%= article.domain %></a>

--- a/app/views/article/index.html.erb
+++ b/app/views/article/index.html.erb
@@ -4,12 +4,12 @@
   <% @articles.each do |article| %>
   <div class="card col-3">
     <a href="<%= article.link %>" target="_blank">
-       <%= image_tag(article.images.first) if article.article_images.attached? %>
+       <%= image_tag(article.images.first, size:'300x200') if article.article_images.attached? %>
     </a>
     <div class="card-body">
       <a href="<%= article.link %>" target="_blank" class="card-text"><%= article.domain %></a>
       <a href="<%= article.link %>" target="_blank"><h5 class="card-title"><%= article.title %></h5></a>
-      <p class="card-text"><%= article.content.split('').first(60).join('') %></p>   
+      <p class="card-text"><%= article.title %></p>   
     </div>
   </div>
   <% end %>

--- a/db/migrate/20200509130755_add_clean_html_column.rb
+++ b/db/migrate/20200509130755_add_clean_html_column.rb
@@ -1,0 +1,5 @@
+class AddCleanHtmlColumn < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :clean_html, :string 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_06_054955) do
+ActiveRecord::Schema.define(version: 2020_05_09_130755) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 2020_05_06_054955) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "user_id", null: false
     t.string "domain"
+    t.string "clean_html"
     t.index ["deleted_at"], name: "index_articles_on_deleted_at"
   end
 


### PR DESCRIPTION
新增 Article Table 欄位 - clean_html
- 目的：供「單篇文章」排版使用
- 欄位內容：放置已清洗完成的 html 
- 清洗事項為：移除轉檔為 json 之後，產生多餘的 backslash

