### PR TITLE
Lynn/畫面優化 - 文章單頁

### DIFF
--- a/app/javascript/scripts/article.js
+++ b/app/javascript/scripts/article.js
@@ -13,4 +13,9 @@ $(document).on('turbolinks:load', function(){
   if (text.length > 0) {
     $alert.addClass('show')
   }
+
+  //單篇文章上的返回鍵
+  $('.inner-page-back-arrow').click(function(){
+    e.preventDefault();
+  })
 });

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,16 +1,14 @@
-<div class="content">
-  <div class="container">
-    <div class="row col-12 justify-content-center mx-auto mt-5">
-      <a href="#">
-        <h2 class="ml-5"><i class="fas fa-arrow-left" onclick="history.back()"></i></h2>
-      </a>
-      <div class="single_article_info">
-        <div class="single_article_title">
-          <h1><%= @article.title %></h1>
-        </div>
-        <div class="single_article_detail">
-          <div class="msgoogle row mt-5 mb-3 justify-content-center align-items-center">
+<div class="container my-5 pt-5">
+  <a href="#" class="inner-page-back-arrow"><h2 class="my-3 d-inline-block"><i class="fas fa-arrow-left" onclick="history.back()"></i></h2></a>      
+  <div class="row col-12 justify-content-center mx-auto">
+    <div class="single_article_info">
+      <div class="single_article_title">
+        <h1><%= @article.title %></h1>
+      </div>
+      <div class="single_article_detail">
+        <div class="msgoogle row mt-5 mb-3 justify-content-center align-items-center">
             <div class="loading d-none">讀取中...</div>
+            
             <% if @article.encode_string != nil %>
               <audio id="js-speech-player" src="data:audio/mpeg;base64,<%= @article.encode_string %>" controls></audio>
             <% else %>
@@ -19,27 +17,23 @@
               <% end %>
               <audio id="js-speech-player" class="d-none" src="###" controls></audio>
             <% end %>
-          </div>
-          <div class="single_article_website row justify-content-center">
-            <p class="px-3">文章來源：<%= @article.domain %> </p>
-            <a href="<%= @article.link %>" target="_blank">查看原始文章</a>
-          </div>
-          <div class="single_article_tags  row justify-content-center mb-3">
-            <% @article.tags.each do |tag| %>
+        </div>
+        <div class="single_article_website row justify-content-center">
+          <p class="px-3">文章來源：<%= @article.domain %> </p>
+          <a href="<%= @article.link %>" target="_blank">查看原始文章</a>
+        </div>
+        <div class="single_article_tags  row justify-content-center mb-3">
+          <% @article.tags.each do |tag| %>
             <span class="badge badge-secondary mx-2"><%= tag.name %></span>
-            <% end %>
-          </div>
+          <% end %>
         </div>
       </div>
-      <div class="single_article_cover w-100">
-        <img src="<%= @article.images.last %>" alt="" width="100%">
-      </div>
-      <article id="content" data-controller="highlight" class="my-5 w-100">        
-        <%= @article.clean_content.html_safe %>       
-        <input type="hidden" data-target="highlight.articleId" value="<%= @article.id %>"> 
-      </article>
     </div>
+    <div class="single_article_cover w-100">
+      <img src="<%= @article.images.last %>" alt="" width="100%">
+    </div>
+    <article class="my-5 w-100">
+      <%= @article.clean_content.html_safe %>
+    </article>
   </div>
 </div>
-<button id="tooltip" class="btn notDisplayed">  
-</button>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -11,7 +11,7 @@
     <li class="nav-item no-arrow row align-content-center mx-3">
       <%= form_for @article, url: articles_path, method:'post', :html => {class: 'd-none d-sm-inline-block form-inline mr-auto ml-md-3 my-2 my-md-0 mw-100 navbar-search'} do |f| %>
         <div class="input-group">
-          <%= f.text_field :link, class: 'form-control bg-light border-0 small', placeholder: '新增文章連結 https://...' %>
+          <%= f.text_field :link, class: 'form-control bg-light border-0 small', placeholder: '新增文章連結 https://...', value: '' %>
           <div class="input-group-append">
             <%= f.submit '儲存', class: 'btn btn-primary' %>
           </div>
@@ -27,9 +27,9 @@
       <div class="dropdown-menu dropdown-menu-right p-3 shadow animated--grow-in" aria-labelledby="searchDropdown1">
         <%= form_for @article, url: articles_path, method:'post', :html => {class: 'form-inline mr-auto w-100 navbar-search'} do |f| %>
           <div class="input-group"> 
-            <%= f.text_field :link, class: 'form-control bg-light border-0 small', placeholder: '新增文章連結 https://...' %>
+            <%= f.text_field :link, class: 'url-input form-control bg-light border-0 small', placeholder: '新增文章連結 https://...', value: '' %>
             <div class="input-group-append">
-              <%= f.submit '儲存', class: 'btn btn-primary' %>
+              <%= f.submit '儲存', class: 'article-save-btn btn btn-primary' %>
             </div>    
           </div>
         <% end %>


### PR DESCRIPTION
- 解決標題與返回鍵被 navbar 擋住的問題
- 為返回鍵新增 `e.preventDefault()`
- 解決單篇文章上方 navbar 的「新增文章」 input 欄位會保留原文章網址的問題